### PR TITLE
fixes statuses not being display

### DIFF
--- a/pkg/api/pull.go
+++ b/pkg/api/pull.go
@@ -156,7 +156,7 @@ func (c *Client) GetPulls(ctx context.Context, owner string, repo string, opt Pu
 
 	var allPulls []*PullRequest
 	for _, pull := range pulls {
-		statuses, ok := statusesMap[pull.GetHead().GetRef()]
+		statuses, ok := statusesMap[pull.GetHead().GetSHA()]
 		if !ok {
 			statuses = make([]*github.RepoStatus, 0)
 		}


### PR DESCRIPTION
statuses is always empty.

```
$ pr show chatwork/dockerfiles -l 'state == `"open"`' | jq .
[
  {
    "id": 322018730,
    "number": 112,
    "state": "open",
    ...
    "statuses": []
  }
]
```
https://github.com/chatwork/dockerfiles/pull/112