### PR TITLE
add --no-exit-code

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/google/go-github/v28/github"
 
@@ -41,17 +40,7 @@ func CheckRun(cmd *cobra.Command, args []string) error {
 		opt.Action = "merge"
 	}
 
-	if err := pr.Check(opt); err != nil {
-		switch err.(type) {
-		case *pr.NoMatchError:
-			if exitCode {
-				os.Exit(127)
-			}
-			return nil
-		}
-		return err
-	}
-	return nil
+	return pr.Check(opt)
 }
 
 var (

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/google/go-github/v28/github"
 
@@ -54,18 +53,7 @@ func MergeRun(cmd *cobra.Command, args []string) error {
 		opt.Rules = append(opt.Rules, fmt.Sprintf("head.sha == `\"%s\"`", action.SHA))
 	}
 
-	if err := pr.Merge(opt); err != nil {
-		switch err.(type) {
-		case *pr.NoMatchError:
-			if exitCode {
-				os.Exit(127)
-			}
-			return nil
-		}
-		return err
-	}
-
-	return nil
+	return pr.Merge(opt)
 }
 
 func init() {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/google/go-github/v28/github"
 
@@ -54,17 +53,7 @@ func ShowRun(cmd *cobra.Command, args []string) error {
 		opt.Rules = append(opt.Rules, fmt.Sprintf("head.sha == `\"%s\"`", action.SHA))
 	}
 
-	if err := pr.Show(opt); err != nil {
-		switch err.(type) {
-		case *pr.NoMatchError:
-			if exitCode {
-				os.Exit(127)
-			}
-			return nil
-		}
-		return err
-	}
-	return nil
+	return pr.Show(opt)
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	//"github.com/k-kinzal/pr/logger"
-	"fmt"
-	"github.com/k-kinzal/pr/cmd"
 	"os"
+
+	"github.com/k-kinzal/pr/cmd"
 	//"github.com/spf13/cobra"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("pr: %s", err))
-		os.Exit(1)
+		os.Exit(255)
 	}
 }


### PR DESCRIPTION
When working with the PR CLI with GitHub Action, there is a [problem that statuses duplicate](https://twitter.com/mumoshu/status/1184455741484097536).
This problem means that once a GitHub Action fails, its SHA status will be broken.

Therefore, add an option to always return `0` in exit code.

```
$ pr --no-exit-code show
pr: accepts 1 arg(s), received 0

Process finished with exit code 0
```

