### PR TITLE
add validate command

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/k-kinzal/pr/pkg/api"
+
+	"golang.org/x/xerrors"
+
+	"github.com/k-kinzal/pr/pkg/pr"
+	"github.com/spf13/cobra"
+)
+
+func ValidateRun(cmd *cobra.Command, args []string) error {
+	result, pulls := pr.Validate(owner, repo, validateOption)
+	if pulls == nil {
+		pulls = make([]*api.PullRequest, 0)
+	}
+	for _, res := range result {
+		if res.Success() {
+			fmt.Fprintln(os.Stderr, fmt.Sprintf("[X] %s", res.String()))
+		} else {
+			fmt.Fprintln(os.Stderr, fmt.Sprintf("[ ] %s", res.String()))
+		}
+	}
+
+	out, err := json.Marshal(pulls)
+	if err != nil {
+		return xerrors.Errorf("show: %s", err)
+	}
+	fmt.Fprintln(os.Stdout, string(out))
+
+	return nil
+}
+
+var (
+	validateOption *pr.ListOption
+	validateCmd    = &cobra.Command{
+		Use:           "validate owner/repo",
+		Short:         "Validate the rules",
+		RunE:          ValidateRun,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+)
+
+func init() {
+	validateOption = setListFrags(validateCmd)
+	rootCmd.AddCommand(validateCmd)
+}

--- a/pkg/pr/validate.go
+++ b/pkg/pr/validate.go
@@ -1,0 +1,85 @@
+package pr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/k-kinzal/pr/pkg/api"
+)
+
+type ValidationResult interface {
+	Success() bool
+	String() string
+}
+
+type ValidationResultSuccess struct {
+	rule    string
+	message string
+}
+
+func (v *ValidationResultSuccess) Success() bool {
+	return true
+}
+
+func (v *ValidationResultSuccess) String() string {
+	return fmt.Sprintf("%s: %s", v.rule, v.message)
+}
+
+type ValidationResultFailed struct {
+	rule string
+	err  error
+}
+
+func (v *ValidationResultFailed) Success() bool {
+	return false
+}
+
+func (v *ValidationResultFailed) String() string {
+	return fmt.Sprintf("%s: %s", v.rule, v.err)
+}
+
+func Validate(owner string, repo string, opt *ListOption) ([]ValidationResult, []*api.PullRequest) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientOption := &api.Options{
+		Token:     token,
+		RateLimit: opt.Rate,
+	}
+	client := api.NewClient(ctx, clientOption)
+
+	pullOption := api.PullsOption{
+		EnableComments: opt.EnableComments,
+		EnableReviews:  opt.EnableReviews,
+		EnableCommits:  opt.EnableCommits,
+		EnableStatuses: opt.EnableStatuses,
+		Rules:          api.NewPullRequestRules([]string{opt.Rules[0]}, opt.Limit),
+	}
+	pulls, err := client.GetPulls(ctx, owner, repo, pullOption)
+	if err != nil {
+		result := []ValidationResult{&ValidationResultFailed{opt.Rules[0], err}}
+		return result, nil
+	}
+
+	r := api.NewPullRequestRules([]string{}, opt.Limit)
+	var results []ValidationResult
+	for _, rule := range opt.Rules {
+		r.Add(rule)
+		p, err := r.Apply(pulls)
+		pulls = p
+		if err != nil {
+			results = append(results, &ValidationResultFailed{rule, err})
+			continue
+		}
+		if len(pulls) == 0 {
+			err := errors.New("no PR matches the rule")
+			results = append(results, &ValidationResultFailed{rule, err})
+			continue
+		}
+		message := fmt.Sprintf("%d PRs matched the rules", len(pulls))
+		results = append(results, &ValidationResultSuccess{rule, message})
+	}
+
+	return results, pulls
+}


### PR DESCRIPTION
I was in trouble while debugging.
It is difficult to determine which rule caused the error and which rule matched the PR.

Therefore, I created a command that can be displayed in rule units.

```
$ pr validate chatwork/dockerfiles --with-statuses \
  -l 'state == `"open"`' \
  -l 'length(statuses) > `0`' \
  -l 'user.name == `"github-action[bot]"`'
[X] state == `"open"`: 1 PRs matched the rules
[X] length(statuses) > `0`: 1 PRs matched the rules
[ ] user.name == `"github-action[bot]"`: no PR matches the rule
[]
```
