### PR TITLE
fixes long description in check command

### DIFF
--- a/pkg/api/status.go
+++ b/pkg/api/status.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"text/template"
 
 	"golang.org/x/sync/errgroup"
@@ -38,6 +39,9 @@ func (c *Client) Status(ctx context.Context, pulls []*PullRequest, opt *StatusOp
 				}
 				description := buf.String()
 				buf.Reset()
+				if len(description) > 140 {
+					description = fmt.Sprintf("%s...", description[:137])
+				}
 
 				if err := contextTemplate.Execute(buf, pull); err != nil {
 					return err


### PR DESCRIPTION
https://github.com/k-kinzal/pr-action/pull/3/checks?check_run_id=307795482
```
pr --no-exit-code check k-kinzal/pr-action --merge -l state == `"open"` -l base.ref == `"master"` -l starts_with(head.ref, `"mod-up-"`) -l user.login == `"github-actions[bot]"`
POST https://api.github.com/repos/k-kinzal/pr-action/statuses/e356dcf316e74c2e03dcfa27d7eba74c1475a594: 422 Validation Failed [{Resource:Status Field:description Code:custom Message:description is too long (maximum is 140 characters)}]
```