### PR TITLE
support label manipuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,24 @@ $ pr merge [owner]/[repo] --with-statuses -l 'state == `"open"`' -l 'length(stat
 [...]
 ```
 
-## Check
+### Label
+
+Append/Remove/Replace labels to PRs that match the rule.
+
+```bash
+$ pr label [owner]/[repo] -l 'state == `"open"`' --action "append" --label "foo"
+...
+$ pr label [owner]/[repo] -l 'state == `"open"`' --action "remove" --label "foo"
+...
+$ pr label [owner]/[repo] -l 'state == `"open"`' --action "replace" --label "foo"
+...
+```
+
+`--action "append"` appends the specified label to the PR that matches the rule.
+`--action "remove"` removes the label specified for the PR that matched the rule.
+`--action "replace"` replaces all labels on PR that match the rule with the specified label.
+
+### Check
 
 When the PR CLI is run on the CI, the rule status is displayed separately from the CI.
 This is a solution to the problem where multiple CI statuses are displayed in GitHub Action.
@@ -67,7 +84,7 @@ $ pr check [owner]/[repo] --merge -l 'number == `1`' -l 'state == `"open"`' -l '
 
 For PR with `number == 1`, merge if the condition is met, or change status to pending if the condition is not met.
 
-## Show
+### Show
 
 Check the PR that matches the rule.
 
@@ -83,7 +100,7 @@ $ pr show [owner]/[repo] --exit-code -l 'number == `1`' -l 'state == `"open"`'
 [...]
 ```
 
-## Validate
+### Validate
 
 Validate the rules.
 

--- a/cmd/label.go
+++ b/cmd/label.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/k-kinzal/pr/pkg/pr"
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func LabelRun(cmd *cobra.Command, args []string) error {
+	labelOption.Action = pr.LabelAction(labelAction)
+
+	pulls, err := pr.Label(owner, repo, labelOption)
+	if err != nil {
+		if _, ok := err.(*pr.NoMatchError); ok {
+			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintln(os.Stdout, "[]")
+			if exitCode {
+				os.Exit(127)
+			}
+			return nil
+		}
+		return err
+	}
+
+	out, err := json.Marshal(pulls)
+	if err != nil {
+		return xerrors.Errorf("merge: %s", err)
+	}
+	fmt.Fprintln(os.Stdout, string(out))
+
+	return nil
+}
+
+var (
+	labelOption *pr.LabelOption
+	labelCmd    = &cobra.Command{
+		Use:           "label owner/repo",
+		Short:         "Manipulate labels that match a rule",
+		RunE:          LabelRun,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	labelAction string
+)
+
+func setLabelFrags(cmd *cobra.Command) *pr.LabelOption {
+	opt := &pr.LabelOption{}
+	cmd.Flags().StringArrayVarP(&opt.Labels, "label", "", nil, "Manipulate labels")
+	cmd.Flags().StringVar(&labelAction, "action", "append", "Manipulation of `append`, `remove`, `replace` for labels")
+	return opt
+}
+
+func init() {
+	labelOption = setLabelFrags(labelCmd)
+	labelOption.ListOption = setListFrags(labelCmd)
+	rootCmd.AddCommand(labelCmd)
+}

--- a/pkg/api/label.go
+++ b/pkg/api/label.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type LabelOption struct {
+	Labels []string
+}
+
+func (c *Client) AppendLabel(ctx context.Context, pulls []*PullRequest, opt *LabelOption) ([]*PullRequest, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for _, pull := range pulls {
+		eg.Go(func(pull *PullRequest) func() error {
+			return func() error {
+				now := Timestamp(time.Now().UTC().Unix())
+				labels, _, err := c.github.Issues.AddLabelsToIssue(ctx, pull.Owner, pull.Repo, int(pull.Number), opt.Labels)
+				if err != nil {
+					return err
+				}
+
+				for _, label := range labels {
+					pull.Labels = append(pull.Labels, newLabel(label))
+				}
+				pull.UpdatedAt = now
+
+				return nil
+			}
+		}(pull))
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return pulls, nil
+}
+
+func (c *Client) RemoveLabel(ctx context.Context, pulls []*PullRequest, opt *LabelOption) ([]*PullRequest, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for _, pull := range pulls {
+		for _, label := range opt.Labels {
+			eg.Go(func(pull *PullRequest, label string) func() error {
+				return func() error {
+					now := Timestamp(time.Now().UTC().Unix())
+					_, err := c.github.Issues.RemoveLabelForIssue(ctx, pull.Owner, pull.Repo, int(pull.Number), label)
+					if err != nil {
+						return err
+					}
+					for i, lbl := range pull.Labels {
+						if lbl.Name == label {
+							pull.Labels[i] = pull.Labels[len(pull.Labels)-1]
+							pull.Labels = pull.Labels[:len(pull.Labels)-1]
+							break
+						}
+					}
+					pull.UpdatedAt = now
+					return nil
+				}
+			}(pull, label))
+		}
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return pulls, nil
+}
+
+func (c *Client) ReplaceLabel(ctx context.Context, pulls []*PullRequest, opt *LabelOption) ([]*PullRequest, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for _, pull := range pulls {
+		eg.Go(func(pull *PullRequest) func() error {
+			return func() error {
+				now := Timestamp(time.Now().UTC().Unix())
+				labels, _, err := c.github.Issues.ReplaceLabelsForIssue(ctx, pull.Owner, pull.Repo, int(pull.Number), opt.Labels)
+				if err != nil {
+					return err
+				}
+				pull.Labels = make([]*Label, len(labels))
+				for i, label := range labels {
+					pull.Labels[i] = newLabel(label)
+				}
+				pull.UpdatedAt = now
+
+				return nil
+			}
+		}(pull))
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return pulls, nil
+}

--- a/pkg/api/label_test.go
+++ b/pkg/api/label_test.go
@@ -1,0 +1,301 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/k-kinzal/pr/pkg/api"
+	"github.com/k-kinzal/pr/test/gen"
+)
+
+func TestClient_AppendLabel(t *testing.T) {
+	gen.Reset()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("POST", "=~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels", func(request *http.Request) (response *http.Response, e error) {
+		var req []string
+		if err := json.NewDecoder(request.Body).Decode(&req); err != nil {
+			return nil, err
+		}
+
+		labels, err := gen.Labels(len(req))
+		if err != nil {
+			return nil, err
+		}
+		for i, name := range req {
+			labels[i].Name = &name
+		}
+
+		resp, err := httpmock.NewJsonResponse(200, labels)
+		if err != nil {
+			return nil, err
+		}
+		resp.Header.Add("X-RateLimit-Limit", "5000")
+		resp.Header.Add("X-RateLimit-Remaining", "4999")
+		resp.Header.Add("X-RateLimit-Reset", fmt.Sprint(time.Now().Unix()))
+		resp.Request = request
+
+		return resp, nil
+	})
+
+	pulls := []*api.PullRequest{
+		{
+			Id:     1,
+			Number: 1,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+		},
+		{
+			Id:     2,
+			Number: 2,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+		},
+		{
+			Id:     3,
+			Number: 3,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+		},
+	}
+
+	ctx := context.Background()
+	client := api.NewClient(ctx, &api.Options{
+		Token:     "xxxx",
+		RateLimit: math.MaxInt32,
+	})
+	opt := &api.LabelOption{
+		Labels: []string{"label1"},
+	}
+	pulls, err := client.AppendLabel(ctx, pulls, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, pull := range pulls {
+		if len(pull.Labels) != 1 {
+			t.Fatalf("len(pulls[%d].labels): expect `1`, but actual `%d`", i, len(pull.Labels))
+		}
+		if pull.Labels[0].Name != "label1" {
+			t.Fatalf("pulls[%d].labels[0].name: expect `label1`, but actual `%s`", i, pull.Labels[0].Name)
+		}
+	}
+
+	info := httpmock.GetCallCountInfo()
+	if info["POST =~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels"] != 3 {
+		t.Fatalf("expect `3`, but actual `%d`: %#v", info["POST =~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels"], info)
+	}
+}
+
+func TestClient_RemoveLabel(t *testing.T) {
+	gen.Reset()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("DELETE", "=~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels/.+", func(request *http.Request) (response *http.Response, e error) {
+		resp, err := httpmock.NewJsonResponse(200, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp.Header.Add("X-RateLimit-Limit", "5000")
+		resp.Header.Add("X-RateLimit-Remaining", "4999")
+		resp.Header.Add("X-RateLimit-Reset", fmt.Sprint(time.Now().Unix()))
+		resp.Request = request
+
+		return resp, nil
+	})
+
+	pulls := []*api.PullRequest{
+		{
+			Id:     1,
+			Number: 1,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+			Labels: []*api.Label{
+				{
+					Name: "label1",
+				},
+			},
+		},
+		{
+			Id:     2,
+			Number: 2,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+			Labels: []*api.Label{
+				{
+					Name: "label1",
+				},
+			},
+		},
+		{
+			Id:     3,
+			Number: 3,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+			Labels: []*api.Label{
+				{
+					Name: "label1",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	client := api.NewClient(ctx, &api.Options{
+		Token:     "xxxx",
+		RateLimit: math.MaxInt32,
+	})
+	opt := &api.LabelOption{
+		Labels: []string{"label1"},
+	}
+	pulls, err := client.RemoveLabel(ctx, pulls, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, pull := range pulls {
+		if len(pull.Labels) != 0 {
+			t.Fatalf("len(pulls[%d].labels): expect `0`, but actual `%d`", i, len(pull.Labels))
+		}
+	}
+
+	info := httpmock.GetCallCountInfo()
+	if info["DELETE =~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels/.+"] != 3 {
+		t.Fatalf("expect `3`, but actual `%d`: %#v", info["DELETE =~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels/.+"], info)
+	}
+}
+
+func TestClient_ReplaceLabel(t *testing.T) {
+	gen.Reset()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("PUT", "=~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels", func(request *http.Request) (response *http.Response, e error) {
+		var req []string
+		if err := json.NewDecoder(request.Body).Decode(&req); err != nil {
+			return nil, err
+		}
+
+		labels, err := gen.Labels(len(req))
+		if err != nil {
+			return nil, err
+		}
+		for i, name := range req {
+			labels[i].Name = &name
+		}
+		resp, err := httpmock.NewJsonResponse(200, labels)
+		if err != nil {
+			return nil, err
+		}
+		resp.Header.Add("X-RateLimit-Limit", "5000")
+		resp.Header.Add("X-RateLimit-Remaining", "4999")
+		resp.Header.Add("X-RateLimit-Reset", fmt.Sprint(time.Now().Unix()))
+		resp.Request = request
+
+		return resp, nil
+	})
+
+	pulls := []*api.PullRequest{
+		{
+			Id:     1,
+			Number: 1,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+			Labels: []*api.Label{
+				{
+					Name: "label1",
+				},
+			},
+		},
+		{
+			Id:     2,
+			Number: 2,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+			Labels: []*api.Label{
+				{
+					Name: "label1",
+				},
+			},
+		},
+		{
+			Id:     3,
+			Number: 3,
+			State:  "open",
+			Head: &api.PullRequestBranch{
+				Sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+			},
+			Owner: "octocat",
+			Repo:  "Hello-World",
+			Labels: []*api.Label{
+				{
+					Name: "label1",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	client := api.NewClient(ctx, &api.Options{
+		Token:     "xxxx",
+		RateLimit: math.MaxInt32,
+	})
+	opt := &api.LabelOption{
+		Labels: []string{"label2"},
+	}
+	pulls, err := client.ReplaceLabel(ctx, pulls, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, pull := range pulls {
+		if len(pull.Labels) != 1 {
+			t.Fatalf("len(pulls[%d].labels): expect `1`, but actual `%d`", i, len(pull.Labels))
+		}
+		if pull.Labels[0].Name != "label2" {
+			t.Fatalf("pulls[%d].labels[0].name: expect `label2`, but actual `%s`", i, pull.Labels[0].Name)
+		}
+	}
+
+	info := httpmock.GetCallCountInfo()
+	if info["PUT =~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels"] != 3 {
+		t.Fatalf("expect `3`, but actual `%d`: %#v", info["PUT =~^https://api.github.com/repos/octocat/Hello-World/issues/\\d+/labels"], info)
+	}
+}

--- a/pkg/pr/label.go
+++ b/pkg/pr/label.go
@@ -1,0 +1,84 @@
+package pr
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/k-kinzal/pr/pkg/api"
+)
+
+type LabelAction string
+
+const (
+	LabelActionAppend  LabelAction = "append"
+	LabelActionRemove  LabelAction = "remove"
+	LabelActionReplace LabelAction = "replace"
+)
+
+type LabelFunc func(labels []string) []string
+
+func RandomizeLabel(labels []string) []string {
+	rand.Seed(time.Now().UnixNano())
+	return []string{labels[rand.Intn(len(labels)-1)]}
+}
+
+type LabelOption struct {
+	Labels   []string
+	Action   LabelAction
+	FuncList []LabelFunc
+	*ListOption
+}
+
+func Label(owner string, repo string, opt *LabelOption) ([]*api.PullRequest, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientOption := &api.Options{
+		Token:     token,
+		RateLimit: opt.Rate,
+	}
+	client := api.NewClient(ctx, clientOption)
+
+	pullOption := api.PullsOption{
+		EnableComments: opt.EnableComments,
+		EnableReviews:  opt.EnableReviews,
+		EnableCommits:  opt.EnableCommits,
+		EnableStatuses: opt.EnableStatuses,
+		EnableChecks:   opt.EnableChecks,
+		Rules:          api.NewPullRequestRules(opt.Rules, opt.Limit),
+	}
+	pulls, err := client.GetPulls(ctx, owner, repo, pullOption)
+	if err != nil {
+		return nil, err
+	}
+	if len(pulls) == 0 {
+		return nil, &NoMatchError{pullOption.Rules}
+	}
+
+	labels := opt.Labels
+	for _, fn := range opt.FuncList {
+		labels = fn(labels)
+	}
+
+	switch opt.Action {
+	case LabelActionAppend:
+		labelOption := &api.LabelOption{
+			Labels: labels,
+		}
+		return client.AppendLabel(ctx, pulls, labelOption)
+	case LabelActionRemove:
+		labelOption := &api.LabelOption{
+			Labels: labels,
+		}
+		return client.RemoveLabel(ctx, pulls, labelOption)
+	case LabelActionReplace:
+		labelOption := &api.LabelOption{
+			Labels: labels,
+		}
+		return client.ReplaceLabel(ctx, pulls, labelOption)
+	}
+
+	return nil, fmt.Errorf("action is expected to be `append`, `remove`, `all`, but was actually %s", opt.Action)
+}

--- a/test/gen/label.go
+++ b/test/gen/label.go
@@ -1,0 +1,37 @@
+package gen
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/google/go-github/v28/github"
+)
+
+// See: https://developer.github.com/v3/pulls/#list-pull-requests
+var labelText = `{"id":208045946,"node_id":"MDU6TGFiZWwyMDgwNDU5NDY=","url":"https://api.github.com/repos/octocat/Hello-World/labels/bug","name":"bug","description":"Something isn't working","color":"f29513","default":true}`
+var label *github.Label
+var labelOnce sync.Once
+
+func Label() (*github.Label, error) {
+	var err error
+	labelOnce.Do(func() {
+		err = json.Unmarshal([]byte(labelText), &label)
+	})
+	if err != nil {
+		return nil, err
+	}
+	l := *label
+	return &l, nil
+}
+
+func Labels(length int) ([]*github.Label, error) {
+	values := make([]*github.Label, length)
+	for i := 0; i < length; i++ {
+		v, err := Label()
+		if err != nil {
+			return nil, err
+		}
+		values[i] = v
+	}
+	return values, nil
+}


### PR DESCRIPTION
Supported the command to operate PR label that matched the rule.

```bash
$ pr label [owner]/[repo] -l 'state == `"open"`' --action "append" --label "foo"
...
$ pr label [owner]/[repo] -l 'state == `"open"`' --action "remove" --label "foo"
...
$ pr label [owner]/[repo] -l 'state == `"open"`' --action "replace" --label "foo"
...
```